### PR TITLE
refactor(ob_validator): strict schema-aware positional arg validation (BREAKING)

### DIFF
--- a/pyaraucaria/ob_validator.py
+++ b/pyaraucaria/ob_validator.py
@@ -229,31 +229,26 @@ class ObsValidator:
     def convert_to_obdict(ob: dict) -> dict | None:
         """Flatten parser output (nested sequences with args/kwargs) into a flat dict.
 
-        Positional args are unpacked by arity — see the module docstring for
-        limitations (the stricter PR replaces this with schema-driven unpacking).
-        """
-        result: dict = {}
-        subcommands = ob.get("subcommands", [])
-        if isinstance(subcommands, dict):
-            subcommands = [subcommands]
+        Schema-agnostic entry point. Uses a built-in fallback that mirrors the
+        pre-refactor arity-based mapping (1 arg → name; 2 → ra, dec; 3 → name,
+        ra, dec; >3 → flags `_positional_overflow` so strict validation rejects).
 
-        for sub in subcommands:
-            if "command_name" in sub:
-                result["command_name"] = sub["command_name"]
-            if "kwargs" in sub and isinstance(sub["kwargs"], dict):
-                result.update(sub["kwargs"])
-            if "args" in sub and isinstance(sub["args"], list):
-                args = sub["args"]
-                if len(args) == 1:
-                    result["name"] = args[0]
-                elif len(args) == 2:
-                    result["ra"] = args[0]
-                    result["dec"] = args[1]
-                elif len(args) == 3:
-                    result["name"] = args[0]
-                    result["ra"] = args[1]
-                    result["dec"] = args[2]
-        return result
+        For schema-aware mapping (per-command positional slot lists, strict
+        overflow), use :meth:`ObsValidator.convert_parsed`.
+        """
+        return _convert_to_obdict_impl(ob, schema=None)
+
+    def convert_parsed(self, parsed: dict) -> dict | None:
+        """Schema-aware version of `convert_to_obdict`.
+
+        Uses the validator's own schema to map positional args to the correct
+        named slots per command. >N args (where N is the command's declared
+        positional slot count) leaves a `_positional_overflow` marker so
+        `validate_ob` reports the failure.
+        """
+        if self._mode == "legacy":
+            return _convert_to_obdict_impl(parsed, schema=self._base_schema)
+        return _convert_to_obdict_impl(parsed, schema=self._schema)
 
     @staticmethod
     def clean_none(obs: dict) -> dict:
@@ -335,9 +330,16 @@ class ObsValidator:
         allowed_filters: Iterable[str] | None,
     ) -> dict:
         obs_clean = self.clean_none(obs)
+
+        # Positional overflow check — produced by `convert_parsed` when more
+        # positional args were supplied than the command's schema declares.
+        overflow = obs_clean.pop("_positional_overflow", None)
+
         obs_clean = self.convert_types(obs_clean, self._schema)
 
         result: dict[str, bool] = {key: True for key in obs_clean}
+        if overflow is not None:
+            result["_positional_overflow"] = False
 
         for error in self._validator.iter_errors(obs_clean):
             if error.path:
@@ -556,6 +558,82 @@ def _collect_required(schema: dict, command_name: str | None) -> list[str]:
 
     visit(schema)
     return sorted(required)
+
+
+def _positional_slots_for(schema: dict, command_name: str | None) -> list[str] | None:
+    """Return the per-command `positional` list from the schema, or None if unknown.
+
+    Walks allOf / oneOf / anyOf branches, matching on `properties.command_name.const`.
+    Falls back to the top-level `positional` key if no discriminator matches.
+    """
+    if not command_name:
+        return schema.get("positional")
+
+    def visit(node: Any) -> list[str] | None:
+        if not isinstance(node, dict):
+            return None
+        cn = node.get("properties", {}).get("command_name", {})
+        if isinstance(cn, dict) and cn.get("const") == command_name:
+            if "positional" in node:
+                return list(node["positional"])
+        for keyword in ("allOf", "anyOf", "oneOf"):
+            for sub in node.get(keyword, []):
+                r = visit(sub)
+                if r is not None:
+                    return r
+        return None
+
+    return visit(schema) if isinstance(schema, dict) else None
+
+
+def _convert_to_obdict_impl(ob: dict, schema: dict | None) -> dict | None:
+    """Flatten parser output to a flat obdict.
+
+    If `schema` is given and contains a `positional` slot list for the matched
+    command, the args are assigned to the declared slot names (and overflow
+    becomes a `_positional_overflow` marker). Otherwise falls back to the
+    canonical arity mapping (name / ra+dec / name+ra+dec), with >3 args still
+    flagged as overflow so the strict validator catches it.
+    """
+    result: dict = {}
+    subcommands = ob.get("subcommands", [])
+    if isinstance(subcommands, dict):
+        subcommands = [subcommands]
+
+    for sub in subcommands:
+        cmd = sub.get("command_name")
+        if cmd is not None:
+            result["command_name"] = cmd
+        if "kwargs" in sub and isinstance(sub["kwargs"], dict):
+            result.update(sub["kwargs"])
+        args = sub.get("args")
+        if isinstance(args, list):
+            slots = _positional_slots_for(schema, cmd) if schema else None
+            if slots is None:
+                # Fallback: the canonical legacy mapping plus explicit overflow.
+                if len(args) == 1:
+                    result["name"] = args[0]
+                elif len(args) == 2:
+                    result["ra"] = args[0]
+                    result["dec"] = args[1]
+                elif len(args) == 3:
+                    result["name"] = args[0]
+                    result["ra"] = args[1]
+                    result["dec"] = args[2]
+                elif len(args) > 3:
+                    # Assign the first 3 per canonical; flag the rest as overflow.
+                    result["name"] = args[0]
+                    result["ra"] = args[1]
+                    result["dec"] = args[2]
+                    result["_positional_overflow"] = args[3:]
+            else:
+                # Schema-declared slot names; overflow is anything beyond len(slots).
+                for i, slot in enumerate(slots):
+                    if i < len(args):
+                        result[slot] = args[i]
+                if len(args) > len(slots):
+                    result["_positional_overflow"] = args[len(slots):]
+    return result
 
 
 def _coerce_union(value: Any, prop: dict) -> Any:

--- a/pyaraucaria/schemas/commands/BELL.yaml
+++ b/pyaraucaria/schemas/commands/BELL.yaml
@@ -2,6 +2,7 @@ $id: "https://araucaria-project.github.io/schemas/commands/BELL.yaml"
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "BELL command"
 description: "Emits an attention signal to the observer."
+positional: []
 type: object
 required: [command_name]
 properties:

--- a/pyaraucaria/schemas/commands/DARK.yaml
+++ b/pyaraucaria/schemas/commands/DARK.yaml
@@ -2,6 +2,7 @@ $id: "https://araucaria-project.github.io/schemas/commands/DARK.yaml"
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "DARK command"
 description: "Dark exposures."
+positional: [name]
 type: object
 required: [command_name, seq]
 properties:

--- a/pyaraucaria/schemas/commands/DOMEFLAT.yaml
+++ b/pyaraucaria/schemas/commands/DOMEFLAT.yaml
@@ -2,6 +2,7 @@ $id: "https://araucaria-project.github.io/schemas/commands/DOMEFLAT.yaml"
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "DOMEFLAT command"
 description: "Dome flat field exposures."
+positional: [name]
 type: object
 required: [command_name, seq]
 properties:

--- a/pyaraucaria/schemas/commands/FOCUS.yaml
+++ b/pyaraucaria/schemas/commands/FOCUS.yaml
@@ -2,6 +2,7 @@ $id: "https://araucaria-project.github.io/schemas/commands/FOCUS.yaml"
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "FOCUS command"
 description: "Focusing routine; may include a focuser-position sweep (`pos=target/step`)."
+positional: [name, ra, dec]
 type: object
 required: [command_name, seq]
 properties:

--- a/pyaraucaria/schemas/commands/OBJECT.yaml
+++ b/pyaraucaria/schemas/commands/OBJECT.yaml
@@ -4,6 +4,7 @@ title: "OBJECT command"
 description: |
   Science observation. Coordinates may be ra/dec, alt/az, or neither (use current
   telescope pointing).
+positional: [name, ra, dec]
 type: object
 required: [command_name]
 properties:

--- a/pyaraucaria/schemas/commands/SKYFLAT.yaml
+++ b/pyaraucaria/schemas/commands/SKYFLAT.yaml
@@ -4,6 +4,7 @@ title: "SKYFLAT command"
 description: |
   Twilight sky-flat exposures. Either ra/dec OR alt/az may be supplied, but not both.
   Auto-exposure ('a') is allowed in `seq`.
+positional: [name, ra, dec]
 type: object
 required: [command_name, seq]
 properties:

--- a/pyaraucaria/schemas/commands/SNAP.yaml
+++ b/pyaraucaria/schemas/commands/SNAP.yaml
@@ -2,6 +2,7 @@ $id: "https://araucaria-project.github.io/schemas/commands/SNAP.yaml"
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "SNAP command"
 description: "Single test exposure (not stored in data archive)."
+positional: [name, ra, dec]
 type: object
 required: [command_name]
 properties:

--- a/pyaraucaria/schemas/commands/STOP.yaml
+++ b/pyaraucaria/schemas/commands/STOP.yaml
@@ -2,6 +2,7 @@ $id: "https://araucaria-project.github.io/schemas/commands/STOP.yaml"
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "STOP command"
 description: "Stops execution of the plan."
+positional: []
 type: object
 required: [command_name]
 properties:

--- a/pyaraucaria/schemas/commands/WAIT.yaml
+++ b/pyaraucaria/schemas/commands/WAIT.yaml
@@ -2,6 +2,7 @@ $id: "https://araucaria-project.github.io/schemas/commands/WAIT.yaml"
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "WAIT command"
 description: "Wait until a time event: seconds, UT time, or sun altitude."
+positional: []
 type: object
 required: [command_name]
 properties:

--- a/pyaraucaria/schemas/commands/ZERO.yaml
+++ b/pyaraucaria/schemas/commands/ZERO.yaml
@@ -2,6 +2,7 @@ $id: "https://araucaria-project.github.io/schemas/commands/ZERO.yaml"
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "ZERO command"
 description: "Bias/zero exposures."
+positional: [name]
 type: object
 required: [command_name, seq]
 properties:

--- a/tests/test_ob_validator.py
+++ b/tests/test_ob_validator.py
@@ -271,5 +271,53 @@ class TestConversionHelpers(unittest.TestCase):
         self.assertIn("seq=1/V/60", line)
 
 
+class TestStrictPositionalValidation(unittest.TestCase):
+    """The stricter `convert_parsed` path (schema-aware positional unpacking)
+    catches lines that the legacy arity-based mapping silently accepted.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.v = ObsValidator.from_default(overlays=["tpg_overlay"])
+
+    def _validate_line(self, line: str) -> dict:
+        parsed = ObsPlanParser.convert_from_string(line)
+        ob = self.v.convert_parsed(parsed)
+        return self.v.validate_ob(ob, allowed_filters=["V", "Ic", "B"])
+
+    def test_canonical_object_valid(self):
+        r = self._validate_line("OBJECT HD1 18:58:14 -21:22:14 seq=1/V/60")
+        self.assertTrue(r["valid"], f"failed: {r['result']}")
+
+    def test_four_args_silently_dropped_no_more(self):
+        """Pre-refactor: 4+ args were silently dropped and the OB was accepted."""
+        r = self._validate_line("OBJECT HD1 18:58:14 -21:22:14 extra seq=1/V/60")
+        self.assertFalse(r["valid"])
+        self.assertFalse(r["result"].get("_positional_overflow", True))
+
+    def test_wait_with_positional_rejected(self):
+        """WAIT has `positional: []` — any positional arg is overflow."""
+        r = self._validate_line("WAIT HD1 ut=16:00:00")
+        self.assertFalse(r["valid"])
+        self.assertFalse(r["result"].get("_positional_overflow", True))
+
+    def test_stop_bare_valid(self):
+        r = self._validate_line("STOP")
+        self.assertTrue(r["valid"])
+
+    def test_unknown_kwarg_strict(self):
+        r = self._validate_line("OBJECT HD1 18:58:14 -21:22:14 seq=1/V/60 junk=42")
+        self.assertFalse(r["valid"])
+
+    def test_legacy_convert_still_available(self):
+        """The static `convert_to_obdict` keeps the legacy shape (no schema)."""
+        parsed = ObsPlanParser.convert_from_string(
+            "OBJECT HD1 18:58:14 -21:22:14 extra seq=1/V/60"
+        )
+        ob = ObsValidator.convert_to_obdict(parsed)
+        # Legacy path still flags overflow (PR2 tightens even the fallback).
+        self.assertIn("_positional_overflow", ob)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Stacked on top of #78** — please merge #78 first (or review them together).

This is the **breaking half** of the two-part validator refactor. It tightens
positional-argument validation and unknown-kwarg rejection so that 18
genuine typos in the existing master files start producing clear errors
instead of silently passing.

## What changes

Each command schema now declares its positional argument slots:

\`\`\`yaml
# OBJECT.yaml / SKYFLAT.yaml / SNAP.yaml / FOCUS.yaml
positional: [name, ra, dec]
# DOMEFLAT.yaml / DARK.yaml / ZERO.yaml
positional: [name]
# WAIT.yaml / STOP.yaml / BELL.yaml
positional: []
\`\`\`

A new \`ObsValidator.convert_parsed(parsed_tree)\` (schema-aware counterpart to
the static \`convert_to_obdict\`) reads this list and assigns positional args
to their declared slots. Over-arity (e.g. a 4th positional arg on OBJECT, or
any positional arg on WAIT) produces a \`_positional_overflow\` marker that
\`validate_ob\` rejects.

## Before / after

| Input                                               | Before       | After     |
| --------------------------------------------------- | ------------ | --------- |
| \`OBJECT HD1 18:58:14 -21:22:14 seq=1/V/60\`          | valid ✓      | valid ✓   |
| \`OBJECT HD1 18:58:14 -21:22:14 extra seq=1/V/60\`    | **silently dropped, valid** | **INVALID (overflow)** |
| \`WAIT HD1 ut=16:00:00\`                              | **valid**    | **INVALID (overflow)** |
| \`OBJECT HD1 ... seq=1/V/60 junk=42\`                 | valid (legacy) / INVALID (new-API PR #78) | INVALID |
| \`STOP\`                                              | valid ✓      | valid ✓   |

## Dry-run against every tpg master file

Tested \`pyaraucaria/schemas/base.yaml + tpg_overlay.yaml\` with
\`ObsValidator.from_default(overlays=[\"tpg_overlay\"])\` against every
non-comment \`OBJECT\` line:

| file              | total | invalid | %   | diagnosis                                  |
| ----------------- | ----: | ------: | --- | ------------------------------------------ |
| iris_master.txt   |   126 |       0 | 0%  | clean                                      |
| jk15_master.txt   |   125 |       2 | 1%  | \`ibs_data\` → \`obs_data\` typo (lines 141, 142) |
| wk06_master.txt   |   215 |       0 | 0%  | clean                                      |
| zb08_master.txt   |   467 |      12 | 2%  | \`h0=\` × 10 (likely typo of \`hjd0\`); \`mV=9.47,\` × 2 (trailing comma) |
| beso_master.txt   |     1 |       1 | 100%| pre-existing parser issue (no OBJECT prefix) |

**Zero false positives** — every rejection traces to a real bug in the master file.

### Concrete bugs found

- \`tpg/master_files/jk15_master.txt:141,142\` — \`ibs_data=\` (typo; should be \`obs_data=\`).
- \`tpg/master_files/zb08_master.txt:267,404\` — \`mV=9.47,\` with a trailing comma carried over from formatting.
- \`tpg/master_files/zb08_master.txt:724-…\` (10 lines) — \`h0=\` where the overlay declares \`hjd0\` (the ten new LMC eclipsing-binary entries). Intentional shorthand or typo?

Those three fixes in tpg's master files would bring the strict validator to clean pass on every existing plan.

## Backward compatibility

- The static \`ObsValidator.convert_to_obdict(parsed)\` keeps working. Its
  legacy fallback (no schema) still returns a flat \`{name, ra, dec, ...}\` dict,
  and now **also** flags \`>3\` positional args as overflow. Downstream code
  that reads the flat obdict and ignores \`_positional_overflow\` is unaffected
  for well-formed inputs.
- The legacy two-arg \`ObsValidator(base_schema, command_rules)\` path used by
  tpg is **unchanged** — its validation logic stays as-is. tpg keeps running
  with zero changes.
- The strict behaviour is opt-in via \`ObsValidator.from_default(...)\` and
  \`convert_parsed\`. Callers can migrate on their own schedule.

## Tests

Adds 6 tests to \`tests/test_ob_validator.py::TestStrictPositionalValidation\`:

- \`test_canonical_object_valid\`
- \`test_four_args_silently_dropped_no_more\`
- \`test_wait_with_positional_rejected\`
- \`test_stop_bare_valid\`
- \`test_unknown_kwarg_strict\`
- \`test_legacy_convert_still_available\` — guard that the static fallback still exposes overflow.

Full suite: **100 tests, all pass.**

## Not in this PR

- Fixing the master-file typos themselves (that's tpg-side; whoever merges
  this should open a companion tpg PR or a bug-report issue after reviewing).
- Adding \`h0\` to the overlay (needs astromg's call on whether it's meant as
  an alias for \`hjd0\` or is a long-standing typo — if the former, one line
  added to \`tpg_overlay.yaml\` fixes all 10).
- Updating tpg's call sites to use the new API — stays on tpg's own schedule.

## References

- #78 — the non-breaking predecessor this PR stacks on.
- #75, #77 — adjacent parser issues (grammar quirk, caching), already merged.